### PR TITLE
types(shared): Improve LooseRequired<T>

### DIFF
--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -5,7 +5,7 @@ export type UnionToIntersection<U> = (
   : never
 
 // make keys required but keep undefined values
-export type LooseRequired<T> = { [P in string & keyof T]: T[P] }
+export type LooseRequired<T> = { [P in keyof Required<T>]: T[P] }
 
 // If the the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360


### PR DESCRIPTION
Improve the implementation of `LooseRequired<T>`.

The purpose of `LooseRequired<T>` is to change the Optional Properties in an Object Type to required, while keeping the undefined type.

In the current version, LooseRequire<T> is implemented as follows.
```typescript
type LooseRequired<T> = { [P in string & keyof T]: T[P] }
```
This implementation has problems when it encounters index signatures, consider the following code.

```typescript
type Result = LooseRequired<{
  [x:string]:any
  a?:1
  b:false
}>
```
The result here is `{ [x: string]: any; }`

This is because when the Object Type contains a string index signature, the keyof T will return string, so all other properties cannot be mapped

But TypeScript keyof T is a lazy value in the case of [P in keyof T], so we can guarantee that every Property can be mapped as long as we don't expand it by using keof T.

To achieve the requirement of `LooseRequired<T>`, we can first set all the properties of T to required and then further map the corresponding types.

Here is the improved `LooseRequired<T>`: 

```typescript
type LooseRequired<T> = { [P in keyof Required<T>]: T[P] }
```

We can do a few tests

```typescript
type Test1 = LooseRequired<{
    [x: string]: any;
    a?: 1;
    b: false;
}>
```
The result is :
```typescript
{
    [x: string]: any;
    a: 1 | undefined;
    b: false;
}
```

Another example is

```typescript
type Test2 = LooseRequired< {
    [x: `on${string}`]: Function;
    onHandle: () => number;
}>
```

The result is
```typescript
{
    [x: `on${string}`]: Function;
    onHandle: () => number;
}
```
You can see that it avoids the attribute value merging problem caused by the keyof T being computed.